### PR TITLE
fix: clean up <C-z> character from command line

### DIFF
--- a/src/Tmux.hs
+++ b/src/Tmux.hs
@@ -425,6 +425,7 @@ runCommand target (Command command) =
       "-t",
       target,
       "C-z",
+      "BSpace",
       command <> " || echo 'Could not run: " <> command <> "'",
       "Enter"
     ]


### PR DESCRIPTION
Fixes the following:
1. `tmux-tui` from non-tmux
2. create new session and attach to it
3. <C-d> to end session
4. `tmux-tui` again from non-tmux
5. `command not found: ^Ztmux-tui`